### PR TITLE
fix(simulate): Make sql and html required

### DIFF
--- a/pollination/custom_energy_sim/entry.py
+++ b/pollination/custom_energy_sim/entry.py
@@ -74,7 +74,7 @@ class CustomEnergySimEntryPoint(DAG):
     )
 
     sql = Outputs.file(
-        source='eplusout.sql', optional=True,
+        source='eplusout.sql',
         description='The result SQL file output by the simulation.'
     )
 
@@ -84,7 +84,7 @@ class CustomEnergySimEntryPoint(DAG):
     )
 
     html = Outputs.file(
-        source='eplustbl.htm', optional=True,
+        source='eplustbl.htm',
         description='The result HTML page with summary reports output by the simulation.'
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pollination-honeybee-energy==0.3.15
+pollination-honeybee-energy==0.3.18
 pollination-alias==0.9.12


### PR DESCRIPTION
Technically, they can be bypassed if the user inputs a specific type of IDF but people keep getting failing simulations that look like they succeed so I am making them required again.